### PR TITLE
fix: Remove bold styling for absentees in Share Menu calendar

### DIFF
--- a/share_ui.js
+++ b/share_ui.js
@@ -368,7 +368,7 @@ function renderShareCalendar(year, month, scheduleDays, participantsList) {
                                     nameSpan.textContent = participant.name;
                                     // Text color will be inherited from slotDiv.style.color
                                     if (slot.isFixedStatus && slot.isFixedStatus[index] === true) {
-                                        nameSpan.style.fontWeight = '800';
+                                        // nameSpan.style.fontWeight = '800'; // Removed as per request
                                     }
                                 } else {
                                     nameSpan.textContent = `ID:${participantId}`;


### PR DESCRIPTION
This commit removes the bold font weight previously applied to participants marked with 'isFixedStatus' (typically absentees or fixed assignments) in the Share Menu calendar view.

The line `nameSpan.style.fontWeight = '800';` within the `renderShareCalendar` function in `share_ui.js` has been commented out. All names will now render with the default font weight, removing this specific emphasis as requested.