### PR TITLE
style: Center-align time and names in Share view calendar

### DIFF
--- a/share_ui.js
+++ b/share_ui.js
@@ -493,7 +493,7 @@ function renderShareCalendar(year, month, scheduleDays, participantsList) {
                         slotDiv.style.marginTop = '0.25rem';
                         slotDiv.style.marginBottom = '0.25rem';
                         slotDiv.style.borderRadius = '0.5rem';
-                        slotDiv.style.textAlign = 'left';
+                        slotDiv.style.textAlign = 'center';
                         slotDiv.style.fontSize = '11px';
                         slotDiv.style.lineHeight = '1.375';
                         slotDiv.style.boxShadow = '0 1px 2px 0 rgba(0, 0, 0, 0.05)';


### PR DESCRIPTION
I modified the `textAlign` style for schedule slots in the `renderShareCalendar` function in `share_ui.js` to `center`. This change ensures that the time and participant names displayed within each calendar cell's schedule block are center-aligned.