### PR TITLE
feat: Implement multiple enhancements to scheduling and master data

### DIFF
--- a/master_data_ui.js
+++ b/master_data_ui.js
@@ -37,6 +37,14 @@ export function renderMasterDataView(containerId, onAdd, onExcelUpload, onDelete
                     </select>
                 </div>
                 <div class="form-group">
+                    <label for="copyType" class="text-sm font-medium text-slate-700">복사구분:</label>
+                    <select id="copyType" name="copyType" class="mt-1 block w-full rounded-md border-slate-300 shadow-sm focus:border-sky-500 focus:ring-sky-500 sm:text-sm py-2 px-3">
+                        <option value="">선택안함</option>
+                        <option value="소복사">소복사</option>
+                        <option value="대복사">대복사</option>
+                    </select>
+                </div>
+                <div class="form-group">
                     <label for="studentPhone" class="text-sm font-medium text-slate-700">학생 연락처:</label>
                     <input type="tel" id="studentPhone" name="studentPhone" class="mt-1 block w-full rounded-md border-slate-300 shadow-sm focus:border-sky-500 focus:ring-sky-500 sm:text-sm py-2 px-3" placeholder="하이픈 없이 숫자만">
                 </div>
@@ -53,14 +61,22 @@ export function renderMasterDataView(containerId, onAdd, onExcelUpload, onDelete
         <div class="mb-6 p-4 border border-slate-200 rounded-lg bg-slate-50">
             <h3 class="text-lg font-medium mb-3 text-sky-600">엑셀로 일괄 업로드</h3>
             <input type="file" id="excelFile" accept="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,.xlsx,.xls" class="block w-full text-sm text-slate-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-sky-100 file:text-sky-700 hover:file:bg-sky-200 mb-2">
-            <button id="uploadExcelBtn" class="btn btn-primary w-full sm:w-auto">
-                <i data-lucide="file-up" class="mr-2 h-5 w-5"></i>엑셀 업로드
-            </button>
+            <div class="flex">
+                <button id="uploadExcelBtn" class="btn btn-primary w-full sm:w-auto">
+                    <i data-lucide="file-up" class="mr-2 h-5 w-5"></i>엑셀 업로드
+                </button>
+                <button id="downloadExcelTemplateBtn" class="btn btn-secondary w-full sm:w-auto ml-2">
+                    <i data-lucide="file-spreadsheet" class="mr-2 h-5 w-5"></i>엑셀양식 다운로드
+                </button>
+            </div>
         </div>
         
         <div class="flex justify-between items-center mb-4">
             <h3 class="text-lg font-medium text-sky-600">등록된 정보 목록</h3>
             <div class="flex space-x-2">
+                <button id="filterSmallCopyBtn" class="btn btn-secondary">
+                    <i data-lucide="users" class="mr-2 h-5 w-5"></i>소복사 관리
+                </button>
                 <button id="deleteSelectedBtn" class="btn btn-danger" disabled>
                     <i data-lucide="trash-2" class="mr-2 h-5 w-5"></i>선택 항목 삭제
                 </button>
@@ -107,6 +123,14 @@ export function renderMasterDataView(containerId, onAdd, onExcelUpload, onDelete
                             <option value="중등">중등</option>
                         </select>
                     </div>
+                <div class="form-group">
+                    <label for="editCopyType" class="text-sm font-medium text-slate-700">복사구분:</label>
+                    <select id="editCopyType" name="copyType" class="mt-1 block w-full rounded-md border-slate-300 shadow-sm focus:border-sky-500 focus:ring-sky-500 sm:text-sm py-2 px-3">
+                        <option value="">선택안함</option>
+                        <option value="소복사">소복사</option>
+                        <option value="대복사">대복사</option>
+                    </select>
+                </div>
                 <div class="form-group">
                     <label for="editStudentPhone" class="text-sm font-medium text-slate-700">학생 연락처:</label>
                     <input type="tel" id="editStudentPhone" name="studentPhone" class="mt-1 block w-full rounded-md border-slate-300 shadow-sm focus:border-sky-500 focus:ring-sky-500 sm:text-sm py-2 px-3" placeholder="하이픈 없이 숫자만">
@@ -221,6 +245,7 @@ export function renderMasterDataTable(participants, onEdit, onDelete, onSelectio
                     <th scope="col" class="p-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">이름</th>
                     <th scope="col" class="p-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">성별</th>
                     <th scope="col" class="p-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">초중구분</th>
+                    <th scope="col" class="p-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">복사구분</th>
                     <th scope="col" class="p-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">학생 연락처</th>
                     <th scope="col" class="p-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">부모 연락처</th>
                     <th scope="col" class="p-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">작업</th>
@@ -235,6 +260,7 @@ export function renderMasterDataTable(participants, onEdit, onDelete, onSelectio
                         <td class="p-3 whitespace-nowrap text-sm text-slate-700">${p.name}</td>
                         <td class="p-3 whitespace-nowrap text-sm text-slate-700">${p.gender}</td>
                         <td class="p-3 whitespace-nowrap text-sm text-slate-700">${p.type}</td>
+                        <td class="p-3 whitespace-nowrap text-sm text-slate-700">${p.copyType || '-'}</td>
                         <td class="p-3 whitespace-nowrap text-sm text-slate-700">${p.studentPhone || '-'}</td>
                         <td class="p-3 whitespace-nowrap text-sm text-slate-700">${p.parentPhone || '-'}</td>
                         <td class="p-3 whitespace-nowrap text-sm font-medium space-x-2">
@@ -276,6 +302,7 @@ export function populateEditForm(participant) {
     document.getElementById('editName').value = participant.name;
     document.getElementById('editGender').value = participant.gender;
     document.getElementById('editType').value = participant.type;
+    document.getElementById('editCopyType').value = participant.copyType || '';
     document.getElementById('editStudentPhone').value = participant.studentPhone || '';
     document.getElementById('editParentPhone').value = participant.parentPhone || '';
     document.getElementById('editParticipantModal').classList.add('active');


### PR DESCRIPTION
This commit introduces a series of features and improvements:

1.  **Absentee Assignment Update (Request #1):** Modified schedule generation logic. Students absent in the previous month now receive their initial 2 forced assignments and are then eligible for further random assignments, up to MAX_ALLOWED_ASSIGNMENTS (typically 3). This allows them to receive more than just the initial fixed slots.

2.  **"복사구분" (Copy Type) for Participants (Request #2):**
    - Added a "복사구분" field to the participant master data, allowing values like "소복사" (Small Copy) or "대복사" (Large Copy).
    - UI updated in master data management for inputting and displaying this field.
    - Excel upload functionality now supports the "복사구분" column.

3.  **Excel Template Download (Request #3):**
    - Added an "엑셀양식" (Excel Template) download button in the master data section.
    - The template includes all necessary columns, including the new "복사구분".

4.  **"소복사관리" (Small Copy Management) Filter (Request #4):**
    - Added a filter button to the master data list to quickly show only participants marked as "소복사".
    - The button toggles between filtering for "소복사" and showing all.

5.  **Vacation Period Scheduling (Request #5 & #6):**
    - Added a "방학" (Vacation) icon button in the schedule generation view.
    - You can click this to set a start and end date for a vacation period.
    - During schedule generation for a month overlapping with the set vacation period, special 10 AM time slots are automatically created on weekdays (Mon-Fri).
    - These 10 AM vacation slots are assigned exclusively to '초등' (elementary) students.

6.  **Prevent "소복사" Co-Assignment (Request #7):**
    - Modified schedule generation logic to prevent two participants who are both marked as "소복사" from being assigned to the same time slot together.

7.  **Highlight "소복사" Names (Request #8):**
    - In the generated schedule calendar, the names of participants marked as "소복사" are now displayed in blue for easy identification.
    - If a "소복사" student is also in a "fixed" assignment (red text), the red "fixed" styling takes precedence.