### PR TITLE
Fix: Correct inspection modal assignment count summation

### DIFF
--- a/schedule_generation_ui.js
+++ b/schedule_generation_ui.js
@@ -453,7 +453,7 @@ export function renderInspectionTable(analysisData, uniqueCategoryKeys, prevMont
 
     // 1. Create Table Header
     const headerCellClasses = 'px-2 py-2 text-left text-xs font-medium text-slate-500 uppercase tracking-wider';
-    const headerTitles = ['초중구분', '이름', '총 배정', '새벽', '1차랜덤', '2차랜덤']; // New fixed headers
+    const headerTitles = ['초중구분', '이름', '총 배정', '새벽', '1차랜덤', '2차랜덤', '기타']; // New fixed headers
 
     headerTitles.forEach(title => {
         const th = document.createElement('th');
@@ -499,7 +499,7 @@ export function renderInspectionTable(analysisData, uniqueCategoryKeys, prevMont
         tdTotal.textContent = participantAnalysis.totalAssignments;
 
         // Aggregated Category Cells ('새벽', '1차랜덤', '2차랜덤')
-        const aggregatedKeysToDisplay = ['새벽', '1차랜덤', '2차랜덤'];
+        const aggregatedKeysToDisplay = ['새벽', '1차랜덤', '2차랜덤', '기타'];
 
         aggregatedKeysToDisplay.forEach(aggKey => {
             const tdAgg = tr.insertCell();


### PR DESCRIPTION
Addresses an issue where the sum of individual displayed assignment categories ('새벽', '1차랜덤', '2차랜덤') in the inspection modal did not always match the '총 배정' (Total Assignments) count.

This was primarily due to assignments to categories like 'elementary_vacation_10am' being included in the total count but not being accounted for in the displayed aggregated categories.

Modifications:

1.  `inspection_logic.js`:
    *   I updated its internal `TIME_SLOT_CONFIG` to be more consistent
      with `schedule_generation_logic.js`.
    *   I modified `getAllCategoryKeys()` to explicitly include
      `elementary_vacation_10am`, ensuring assignments to this category
      are tracked.
    *   In `analyzeScheduleForInspection`, I implemented logic to sum up counts
      from any category not part of '새벽', '1차랜덤', or '2차랜덤'
      into a new '기타' (Other) aggregated category. This ensures all
      assignments contribute to the displayed summed categories.
    *   The `newAggregatedCategoryKeys` returned now includes '기타'.

2.  `schedule_generation_ui.js`:
    *   In `renderInspectionTable`, I updated the table headers
      (`headerTitles`) and the list of keys to display
      (`aggregatedKeysToDisplay`) to include the new '기타' column.
      This allows the UI to render the counts for this 'Other' category.

With these changes, the sum of '새벽', '1차랜덤', '2차랜덤', and '기타' columns in the inspection modal should now accurately reflect the '총 배정' count.