### PR TITLE
Fix: Adjust button layout in Master Data Management for mobile

### DIFF
--- a/master_data_ui.js
+++ b/master_data_ui.js
@@ -72,14 +72,14 @@ export function renderMasterDataView(containerId, onAdd, onExcelUpload, onDelete
         
         <div class="flex justify-between items-center mb-4">
             <h3 class="text-lg font-medium text-sky-600">등록된 정보 목록</h3>
-            <div class="flex space-x-2">
-                <button id="filterSmallCopyBtn" class="btn btn-secondary">
+            <div class="flex flex-col sm:flex-row gap-2 mb-2 sm:mb-0">
+                <button id="filterSmallCopyBtn" class="btn btn-secondary w-full sm:w-auto">
                     <i data-lucide="users" class="mr-2 h-5 w-5"></i>소복사 관리
                 </button>
-                <button id="deleteSelectedBtn" class="btn btn-danger" disabled>
+                <button id="deleteSelectedBtn" class="btn btn-danger w-full sm:w-auto" disabled>
                     <i data-lucide="trash-2" class="mr-2 h-5 w-5"></i>선택 항목 삭제
                 </button>
-                <button id="deleteAllBtn" class="btn btn-danger">
+                <button id="deleteAllBtn" class="btn btn-danger w-full sm:w-auto">
                     <i data-lucide="alert-triangle" class="mr-2 h-5 w-5"></i>전체 삭제
                 </button>
             </div>


### PR DESCRIPTION
The buttons ('소복사관리', '선택항목삭제', '전체삭제') in the Master Data Management section were breaking on mobile views due to being forced onto a single line.

This commit updates the Tailwind CSS classes for the button container from 'flex space-x-2' to 'flex flex-col sm:flex-row gap-2 mb-2 sm:mb-0'. Additionally, the buttons themselves now have 'w-full sm:w-auto' classes, making them stack vertically and take full width on mobile screens, while reverting to a row layout with auto width on small (sm) screens and larger. This matches the responsive behavior of buttons in the Share Menu.

Please manually test that the buttons stack correctly on mobile and display as a row on desktop.