### PR TITLE
Feat: Enhance Share Menu with consolidated downloads and schedule con…

### DIFF
--- a/schedule_generation_logic.js
+++ b/schedule_generation_logic.js
@@ -1,4 +1,5 @@
 import * as db from './db.js';
+import { isScheduleConfirmed } from './share_logic.js';
 
 const TIME_SLOT_CONFIG = {
     'Mon': [{ time: '06:00', type: 'elementary', sequential: true, categoryKey: 'elementary_6am' }],
@@ -81,6 +82,15 @@ function isPairingAllowed(p1_id, p2_id, participantsMap) {
 }
 
 export async function generateSchedule(year, month) {
+    // Add this block at the beginning
+    const scheduleIsConfirmed = await isScheduleConfirmed(year, month);
+    if (scheduleIsConfirmed) {
+        console.log(`Schedule generation for ${year}-${month} blocked because it is confirmed.`);
+        // Throw a specific error or return an object that the UI layer can uniquely identify.
+        // Using an error with a specific message is common.
+        throw new Error(`SCHEDULE_CONFIRMED: ${year}년 ${month}월의 일정은 이미 확정되었습니다. 재생성할 수 없습니다.`);
+    }
+
     const MAX_ALLOWED_ASSIGNMENTS = 3;
 
     const vacationStartDateStr = sessionStorage.getItem('vacationStartDate');

--- a/share_logic.js
+++ b/share_logic.js
@@ -1,4 +1,5 @@
 import * as db from './db.js';
+import { setScheduleConfirmation, getScheduleConfirmation, removeScheduleConfirmation } from './db.js';
 
 export async function getScheduleForMonth(year, month) {
     return await db.getSchedule(year, month);
@@ -42,6 +43,54 @@ export async function unassignParticipant(year, month, date, time, participantId
     timeSlot.assigned = timeSlot.assigned.filter(id => id !== participantIdToUnassign);
     
     await db.saveSchedule(year, month, scheduleData);
+}
+
+export async function confirmSchedule(year, month) {
+    if (!year || !month) {
+        console.error("confirmSchedule: Year and month are required.");
+        return { success: false, error: "Year and month are required." };
+    }
+    try {
+        await setScheduleConfirmation(year, month, true);
+        console.log(`Schedule for ${year}-${month} confirmed in share_logic.`);
+        return { success: true };
+    } catch (error) {
+        console.error(`Error confirming schedule for ${year}-${month}:`, error);
+        return { success: false, error: error.message || "Failed to confirm schedule." };
+    }
+}
+
+export async function cancelScheduleConfirmation(year, month) {
+    if (!year || !month) {
+        console.error("cancelScheduleConfirmation: Year and month are required.");
+        return { success: false, error: "Year and month are required." };
+    }
+    try {
+        await removeScheduleConfirmation(year, month);
+        console.log(`Schedule confirmation for ${year}-${month} cancelled in share_logic.`);
+        return { success: true };
+    } catch (error) {
+        console.error(`Error cancelling schedule confirmation for ${year}-${month}:`, error);
+        return { success: false, error: error.message || "Failed to cancel schedule confirmation." };
+    }
+}
+
+export async function isScheduleConfirmed(year, month) {
+    if (!year || !month) {
+        console.error("isScheduleConfirmed: Year and month are required.");
+        // Return true or throw error? Let's return a value indicating uncertainty or error.
+        // For now, let's assume if year/month are invalid, it cannot be confirmed.
+        return false;
+    }
+    try {
+        const confirmed = await getScheduleConfirmation(year, month);
+        return confirmed;
+    } catch (error) {
+        console.error(`Error checking schedule confirmation for ${year}-${month}:`, error);
+        // In case of error, should we assume not confirmed or propagate error?
+        // For safety, let's assume not confirmed if there's an error reading status.
+        return false;
+    }
 }
 
 export async function replaceParticipant(year, month, date, time, participantIdToReplace, newParticipantId) {


### PR DESCRIPTION
…firmation

This commit introduces major enhancements to the Share Menu:

1.  **Consolidated Downloads:**
    - The separate "Image Download" and "Excel Download" buttons have been removed from the Share Menu.
    - A new, single "다운로드" (Download) button has been added.
    - Clicking this button now triggers both the image (.png) and Excel (.xlsx) downloads for the selected schedule.
    - This change is implemented in `share_ui.js`.

2.  **Schedule Confirmation Feature:**
    - You can now mark a month's schedule as "confirmed" via the Share Menu.
    - **Database:**
        - `db.js` was updated: DB_VERSION incremented to 5.
        - A new object store `scheduleConfirmations` (keyPath: ['year', 'month']) was added to store confirmation status. - Helper functions `setScheduleConfirmation`, `getScheduleConfirmation`, and `removeScheduleConfirmation` were added to `db.js`.
    - **Logic Layer:** - `share_logic.js` now includes `confirmSchedule`, `cancelScheduleConfirmation`, and `isScheduleConfirmed` functions that interact with the new DB store.
    - **Share Menu UI (`share_ui.js`):**
        - A new button "일정확정" (Confirm Schedule) is added next to "일정조회".
        - Clicking "일정확정" marks the schedule for the selected year/month as confirmed and changes the button text/icon to "확정해제" (Cancel Confirmation) and style to `btn-warning`. - Clicking "확정해제" removes the confirmation status and reverts the button to "일정확정" and `btn-primary` style. - The button's state is updated dynamically based on the current year/month's confirmation status.
    - **Schedule Generation Impact (`schedule_generation_logic.js` & `schedule_generation_ui.js`):** - The `generateSchedule` function in `schedule_generation_logic.js` now first checks if the target year/month's schedule is confirmed using `isScheduleConfirmed` from `share_logic.js`. - If confirmed, it throws a specific error (`SCHEDULE_CONFIRMED:` prefix). - The `handleGenerateSchedule` function in `schedule_generation_ui.js` catches this specific error and displays a user-friendly warning message (e.g., "해당 월의 일정은 이미 확정되었습니다. 재생성할 수 없습니다.") without clearing the existing calendar view. - The `displayMessage` function in `schedule_generation_ui.js` was updated to support a 'warning' message type with yellow styling.

3.  **Button Layout in Share Menu:**
    - The buttons in the Share Menu are now arranged as: "일정조회" (View Schedule), "일정확정/확정해제" (Confirm/Cancel), "다운로드" (Download).
    - Responsive classes ensure they stack on mobile and form a row on larger screens.

These changes provide you with more control over schedule finalization and a streamlined download experience.