### PR TITLE
I've added diagnostic logging to help understand the schedule confirm…

### DIFF
--- a/db.js
+++ b/db.js
@@ -101,6 +101,7 @@ export async function getScheduleConfirmation(year, month) {
     const store = tx.objectStore(SCHEDULE_CONFIRMATIONS_STORE_NAME);
     const record = await store.get([year, month]);
     await tx.done;
+    console.log(`[db.js] getScheduleConfirmation for ${year}-${month}: Record found:`, JSON.stringify(record), 'Will return:', record ? record.confirmed : false);
     return record ? record.confirmed : false; // Default to false if no record found
 }
 

--- a/schedule_generation_logic.js
+++ b/schedule_generation_logic.js
@@ -84,12 +84,14 @@ function isPairingAllowed(p1_id, p2_id, participantsMap) {
 export async function generateSchedule(year, month) {
     // Add this block at the beginning
     const scheduleIsConfirmed = await isScheduleConfirmed(year, month);
+    console.log(`[schedule_generation_logic.js] generateSchedule: isScheduleConfirmed returned: ${scheduleIsConfirmed} for ${year}-${month}`);
     if (scheduleIsConfirmed) {
-        console.log(`Schedule generation for ${year}-${month} blocked because it is confirmed.`);
+        console.log(`[schedule_generation_logic.js] Schedule generation for ${year}-${month} BLOCKED because it is confirmed.`);
         // Throw a specific error or return an object that the UI layer can uniquely identify.
         // Using an error with a specific message is common.
         throw new Error(`SCHEDULE_CONFIRMED: ${year}년 ${month}월의 일정은 이미 확정되었습니다. 재생성할 수 없습니다.`);
     }
+    console.log(`[schedule_generation_logic.js] Schedule generation for ${year}-${month} PROCEEDING.`);
 
     const MAX_ALLOWED_ASSIGNMENTS = 3;
 


### PR DESCRIPTION
…ation process.

Specifically, I've added console logging to:
- `db.js` in the `getScheduleConfirmation` function to show the record found and its status.
- `schedule_generation_logic.js` in the `generateSchedule` function to show the result of `isScheduleConfirmed` and whether generation is blocked or proceeding.

This logging should help diagnose an issue where schedule generation proceeds for a schedule that has already been confirmed.