### PR TITLE
Fix: 일정 확정 데이터 저장 오류 해결

### DIFF
--- a/db.js
+++ b/db.js
@@ -28,7 +28,7 @@ export function __clearMockData() {
 }
 
 const DB_NAME = 'SchedulePWA_DB';
-const DB_VERSION = 5; // Incremented DB version
+const DB_VERSION = 6; // Incremented DB version
 const PARTICIPANTS_STORE_NAME = 'participants';
 const SCHEDULES_STORE_NAME = 'schedules';
 const SCHEDULE_CONFIRMATIONS_STORE_NAME = 'scheduleConfirmations'; // New store name
@@ -79,9 +79,10 @@ export function openDB() {
                 store.createIndex('participantMonthIndex', ['participantId', 'year', 'month'], { unique: false });
             }
             // Add scheduleConfirmations store if it doesn't exist
-            if (!tempDb.objectStoreNames.contains(SCHEDULE_CONFIRMATIONS_STORE_NAME)) {
-                tempDb.createObjectStore(SCHEDULE_CONFIRMATIONS_STORE_NAME, { keyPath: ['year', 'month'] });
+            if (tempDb.objectStoreNames.contains(SCHEDULE_CONFIRMATIONS_STORE_NAME)) {
+                tempDb.deleteObjectStore(SCHEDULE_CONFIRMATIONS_STORE_NAME);
             }
+            tempDb.createObjectStore(SCHEDULE_CONFIRMATIONS_STORE_NAME, { keyPath: ['year', 'month'] });
         };
     });
 }


### PR DESCRIPTION
IndexedDB의 scheduleConfirmations 저장소에 데이터가 정상적으로 저장되지 않는 문제를 해결했습니다.

- DB_VERSION을 5에서 6으로 올렸습니다.
- onupgradeneeded 함수 로직을 수정하여, scheduleConfirmations 저장소가 이미 존재할 경우 삭제 후 재생성하도록 변경했습니다. 이를 통해 손상된 저장소로 인해 발생할 수 있는 데이터 저장 문제를 방지합니다.

이 변경으로 인해, 일정 확정 상태가 정확하게 저장되고 조회되어, 확정된 월에는 더 이상 일정이 생성되지 않도록 하는 로직이 올바르게 동작할 것으로 기대됩니다.