### PR TITLE
Feature: Display copy type in share menu participant list

### DIFF
--- a/share_ui.js
+++ b/share_ui.js
@@ -864,7 +864,7 @@ async function populateParticipantSelect() {
         if (p.type === '초등') typeColorClass = 'text-sky-700';
         else if (p.type === '중등') typeColorClass = 'text-emerald-700';
         
-        option.innerHTML = `${p.name} (<span class="${typeColorClass}">${p.type}</span>, ${p.gender})`;
+        option.innerHTML = `${p.name} (<span class="${typeColorClass}">${p.type}</span>, ${p.gender}, ${p.copyType})`;
         modalParticipantSelect.appendChild(option);
     });
 }


### PR DESCRIPTION
I've added the '복사구분' (copyType) to the participant information displayed in the modal when you change assignments in the '공유' (share) menu.

The participant list in the assignment change modal now shows: 이름 (초중구분, 성별, 복사구분)

This provides you with more context when selecting a participant for an assignment change.